### PR TITLE
Add basic styling

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title }}</title>
+    <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}">
+  </head>
+
+  <body>
+    <main id="content" class="page-content" role="main">
+      {{ content }}
+    </main>
+
+    <footer class="page-footer">
+      <span>
+        For suggestions, requests, and the like, see the <a href="{{ site.github.repository_url }}">GitHub repository</a>.
+      </span>
+    </footer>
+  </body>
+</html>

--- a/src/_pages/index.markdown
+++ b/src/_pages/index.markdown
@@ -1,5 +1,7 @@
 ---
 permalink: /
+layout: default
+title: Selene Archive
 ---
 
 # An organized collection of Selene Da Silva's clips

--- a/src/_pages/index.markdown
+++ b/src/_pages/index.markdown
@@ -299,6 +299,3 @@ Useful clips that don't quite fit into any other category.
 * [rico nasty "Yeah"](https://clyp.it/krq1o2u1)
 * [overtone singing](https://clyp.it/qwqczu5z)
 
-***
-
-For suggestions, requests, and the like, see the [GitHub repository](https://github.com/selenearchive/selenearchive.github.io/).

--- a/src/_sass/colors.scss
+++ b/src/_sass/colors.scss
@@ -1,0 +1,10 @@
+// Site background
+$body-bg-color: #eae8e5;
+
+// Text
+$body-text-color: #606c71;
+$body-link-color: #1e6bb8;
+$body-hover-color: #1a4977;
+
+// Borders
+$border-color: #494949;

--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -1,0 +1,72 @@
+@mixin large {
+    @media screen and (min-width: #{64em}) {
+        @content;
+    }
+}
+
+@mixin medium {
+    @media screen and (min-width: #{42em}) and (max-width: #{64em}) {
+        @content;
+    }
+}
+
+@mixin small {
+    @media screen and (max-width: #{42em}) {
+        @content;
+    }
+}
+
+body {
+    padding: 0;
+    margin: 0;
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    background: $body-bg-color;
+    color: $body-text-color;
+}
+
+a {
+    color: $body-link-color;
+    text-decoration: none;
+
+    &:hover {
+        color: $body-hover-color;
+    }
+}
+
+.page-content {
+    word-break: break-word;
+
+    @include large {
+        margin: 0 auto;
+        max-width: 54rem;
+        padding: 2rem 6rem;
+        font-size: 1.1rem;
+    }
+    @include medium {
+        padding: 2rem 4rem;
+        font-size: 1.1rem;
+    }
+    @include small {
+        padding: 2rem 1rem;
+        font-size: 1rem;
+    }
+}
+
+.page-footer {
+    text-align: center;
+    font-weight: bold;
+    margin: 1rem;
+
+    @include large {
+        font-size: 1rem;
+    }
+
+    @include medium {
+        font-size: 1rem;
+    }
+
+    @include small {
+        font-size: 0.9rem;
+    }
+}

--- a/src/assets/css/styles.scss
+++ b/src/assets/css/styles.scss
@@ -1,0 +1,6 @@
+---
+---
+@charset "utf-8";
+
+@import "colors";
+@import "layout";


### PR DESCRIPTION
This adds some basic styling that will make the website prettier on desktop and mobile. This version does have a footer with the repo link but does not have a header/navigation bar.

Here's a preview of what the website will look like:
![Screenshot from 2024-05-08 00-48-42](https://github.com/selenearchive/selenearchive.github.io/assets/48052652/32ae4535-4bda-44f0-816f-cd050aa9d797)

I'm not good with colors so I separated that into a separate file (`colors.scss`), where anyone can make changes to the text, background, and link colors -- or any other colors that will be added in the future.
