### PR TITLE
Force padding and line height in player close button

### DIFF
--- a/_sass/player.scss
+++ b/_sass/player.scss
@@ -20,6 +20,8 @@
     align-self: flex-end;
     margin-right: 0.5em;
     margin-bottom: 0.5em;
+    padding: 0;
+    line-height: 0;
 
     button {
         width: 2.5em;


### PR DESCRIPTION
Make sure browser custom styling doesn't interfere with button text alignment.